### PR TITLE
Fix inclusion of Triton.targets in NuGet package

### DIFF
--- a/src/Triton/Triton.csproj
+++ b/src/Triton/Triton.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net40;net35</TargetFrameworks>
@@ -29,7 +29,7 @@
       <Pack>true</Pack>
       <PackagePath>runtimes/</PackagePath>
     </Content>
-    <None Update="runtimes\Triton.targets">
+    <None Include="runtimes\Triton.targets">
       <Pack>true</Pack>
       <PackagePath>build/net40/;build/net35/</PackagePath>
     </None>

--- a/src/Triton/runtimes/Triton.targets
+++ b/src/Triton/runtimes/Triton.targets
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\lua\x64\lua53.dll">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\lua53.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>lua/x64/lua53.dll</Link>
+      <Link>runtimes/win-x64/lua53.dll</Link>
       <Visible>false</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\lua\x64\liblua53.dylib">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\liblua53.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>lua/x64/liblua53.dylib</Link>
+      <Link>runtimes/osx-x64/liblua53.dylib</Link>
       <Visible>false</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\lua\x64\liblua53.so">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\liblua53.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>lua/x64/liblua53.so</Link>
+      <Link>runtimes/linux-x64/liblua53.so</Link>
       <Visible>false</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\lua\x86\lua53.dll">
+    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\lua53.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>lua/x86/lua53.dll</Link>
+      <Link>runtimes/win-x86/lua53.dll</Link>
       <Visible>false</Visible>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
It's required for .NET Framework target as native libraries have to be copied to target app output directory.

Currently this library works for .NET Core target only. This PR makes it work for .NET Framework target as well.

@kevzhao2, can you please publish a NuGet package after merge?
BTW, thanks for the great library!